### PR TITLE
3.6.4

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,12 +12,13 @@ class App extends StatelessWidget {
       theme: ThemeData(
         primarySwatch: Colors.blue,
       ),
-      home: MyFirstStateFullWidget(),
+      home: MyFirstWidget(),
     );
   }
 }
 
 class MyFirstWidget extends StatelessWidget {
+  MyFirstWidget({Key? key}) : super(key: key);
 
   // void getContext(){
   //   print(context.runtimeType);
@@ -37,6 +38,7 @@ class MyFirstWidget extends StatelessWidget {
 }
 
 class MyFirstStateFullWidget extends StatefulWidget {
+  MyFirstStateFullWidget({Key? key}) : super(key: key);
 
   _MyFirstStateFullWidgetState createState() => _MyFirstStateFullWidgetState();
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,14 +1,14 @@
 import 'package:flutter/material.dart';
 
 void main() {
-  runApp(MyApp());
+  runApp(App());
 }
 
-class MyApp extends StatelessWidget {
+class App extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Flutter Demo',
+      title: 'Changed title',
       theme: ThemeData(
         primarySwatch: Colors.blue,
       ),
@@ -18,6 +18,10 @@ class MyApp extends StatelessWidget {
 }
 
 class MyFirstWidget extends StatelessWidget {
+
+  // void getContext(){
+  //   print(context.runtimeType);
+  // }
 
   @override
   Widget build(BuildContext context) {
@@ -40,6 +44,10 @@ class MyFirstStateFullWidget extends StatefulWidget {
 class _MyFirstStateFullWidgetState extends State<MyFirstStateFullWidget> {
   int buildCounter = 0;
 
+  void getContext() {
+    print('${context.runtimeType}');
+  }
+
   void updateCounter(){
     setState(() {
       buildCounter +=1;
@@ -50,6 +58,7 @@ class _MyFirstStateFullWidgetState extends State<MyFirstStateFullWidget> {
   Widget build(BuildContext context) {
     updateCounter();
     print(buildCounter);
+    getContext();
     return Container(
       child: Center(
         child: Text('Hello $buildCounter'),

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -13,7 +13,7 @@ import 'package:places/main.dart';
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(MyApp());
+    await tester.pumpWidget(App());
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);


### PR DESCRIPTION
1. Переименуйте файл main.dart в start.dart. Запустите проект. Почему результат именно таков?
 - Проект запустился, так как в файле есть функция main

В методе build() верните MaterialApp в поле home поставьте Stateless виджет из предыдущего домашнего задания(см. урок про виджеты). Рассмотрите его параметры. Задайте поле title. Запустите на Android. Где отобразится значение этого поля?
- На своем эмуляторе не нашел где должно было поменять, использую Pixel 2 API 30 см скриншот 
![Снимок экрана 2021-07-01 в 14 03 43](https://user-images.githubusercontent.com/23622693/124121441-2f07c800-da75-11eb-87e5-50c3e6a316d6.png)


Перейдем к рассмотрению контекста. В вашем Stateless виджет создайте функцию, которая будет возвращать context.runtimeType. Функция должна быть без аргументов. Получится ли ее реализовать в данном виджете?
- Реализовать не получилось, так как доступа к контексту вне build функции у stateless виджета нету 

Проделайте предыдущий пункт в рамках Stateful. В чем разница?
 - доступ к контексту есть, выводит StatefulElement